### PR TITLE
Обновляет регулярку на readmanga

### DIFF
--- a/readmanga/readmanga.go
+++ b/readmanga/readmanga.go
@@ -221,7 +221,7 @@ func DownloadChapter(downData data.DownloadOpts, curChapter data.ChaptersList) (
 		return nil, err
 	}
 
-	r := regexp.MustCompile(`rm_h\.initReader\(\s\[\d,\d\],\s\[(.+)\],\s0,\sfalse.+\);`)
+	r := regexp.MustCompile(`rm_h\.initReader\(\s\[?\d?,?\d?\]?,?\s?\[(.+)\],\s0,\sfalse.+\);`)
 
 	chList := r.FindStringSubmatch(string(pageBody))
 


### PR DESCRIPTION
Походу поменялась регулярка на readmanga и теперь не качается манга от слова совсем (хотя я проверял лишь на паре тайтлов)

Коммит дает возможность обрабатывать как предыдущие, так и новые 

Несколько вариантов. Этот вариант немного грязный, но рабочий. Если нужно почище, то можно обсудить, какой будет правильнее для проекта сделать или дождаться , когда и этот вариант сломается и надо будет сделать нормально